### PR TITLE
Fix wrapper-upgrade-gradle-plugin task ran by validation scripts

### DIFF
--- a/.github/workflows/run-experiments-wrapper-upgrade-gradle-plugin.yml
+++ b/.github/workflows/run-experiments-wrapper-upgrade-gradle-plugin.yml
@@ -11,7 +11,7 @@ env:
   GRADLE_ENTERPRISE_URL: "https://ge.solutions-team.gradle.com"
   GRADLE_ENTERPRISE_ACCESS_KEY: "${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}"
   GIT_REPO: "https://github.com/gradle/wrapper-upgrade-gradle-plugin"
-  TASKS: "build -x signArchives -x test"
+  TASKS: "build -x signPluginMavenPublication -x test"
 
 jobs:
   Experiment:


### PR DESCRIPTION
plugin-publish plugin has been upgraded, signing task to exclude has changed.