### PR TITLE
Make JUnit workflow fail if not fully cacheable

### DIFF
--- a/.github/workflows/run-experiments-junit5.yml
+++ b/.github/workflows/run-experiments-junit5.yml
@@ -50,7 +50,7 @@ jobs:
           gitRepo: ${{ env.GIT_REPO }}
           tasks: ${{ env.TASKS }}
           gradleEnterpriseUrl: ${{ env.GRADLE_ENTERPRISE_URL }}
-          failIfNotFullyCacheable: false
+          failIfNotFullyCacheable: true
         if: matrix.experimentId == 2
       - name: Run experiment 3
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/experiment-3@actions-stable
@@ -60,5 +60,5 @@ jobs:
           gitRepo: ${{ env.GIT_REPO }}
           tasks: ${{ env.TASKS }}
           gradleEnterpriseUrl: ${{ env.GRADLE_ENTERPRISE_URL }}
-          failIfNotFullyCacheable: false
+          failIfNotFullyCacheable: true
         if: matrix.experimentId == 3


### PR DESCRIPTION
Follow up to https://github.com/junit-team/junit5/pull/3097

Signed-off-by: Jerome Prinet <jprinet@gradle.com>