### PR TITLE
Do not execute javadoc task

### DIFF
--- a/.github/workflows/run-experiments-opentelemetry.yml
+++ b/.github/workflows/run-experiments-opentelemetry.yml
@@ -10,7 +10,7 @@ on:
 env:
   GRADLE_ENTERPRISE_URL: "https://ge.solutions-team.gradle.com"
   GIT_REPO: "https://github.com/open-telemetry/opentelemetry-java-instrumentation"
-  TASKS: "assemble"
+  TASKS: "assemble -x javadoc"
 
 jobs:
   Experiment:


### PR DESCRIPTION
Javadoc is [skipped](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/.github/workflows/build-common.yml#L114) for original workflow

Signed-off-by: Jerome Prinet <jprinet@gradle.com>