### PR TITLE
Do not fail Micronaut if not fully cacheable

### DIFF
--- a/.github/workflows/run-experiments-micronaut.yml
+++ b/.github/workflows/run-experiments-micronaut.yml
@@ -53,7 +53,7 @@ jobs:
           tasks: ${{ env.TASKS }}
           args: ${{ env.ARGS }}
           gradleEnterpriseUrl: ${{ env.GRADLE_ENTERPRISE_URL }}
-          failIfNotFullyCacheable: true
+          failIfNotFullyCacheable: false
         if: matrix.experimentId == 2
       - name: Run experiment 3
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/experiment-3@actions-stable
@@ -64,5 +64,5 @@ jobs:
           tasks: ${{ env.TASKS }}
           args: ${{ env.ARGS }}
           gradleEnterpriseUrl: ${{ env.GRADLE_ENTERPRISE_URL }}
-          failIfNotFullyCacheable: true
+          failIfNotFullyCacheable: false
         if: matrix.experimentId == 3


### PR DESCRIPTION
:core-bom:checkBom is randomly getting difference on repository input property

Signed-off-by: Jerome Prinet <jprinet@gradle.com>