### PR TITLE
Run AndroidX biometric with Java 17

### DIFF
--- a/.github/workflows/run-experiments-androidx.yml
+++ b/.github/workflows/run-experiments-androidx.yml
@@ -35,10 +35,10 @@ jobs:
         run: |
           echo "JAVA_HOME=$JAVA_HOME" >> $GITHUB_ENV
           echo "JAVA_TOOLS_JAR=$JAVA_HOME/lib/tools.jar" >> $GITHUB_ENV
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: "11"
+          java-version: "17"
           distribution: "temurin"
       - name: Set up Android SDK
         uses: android-actions/setup-android@v2


### PR DESCRIPTION
AndroidX was failing due to an issue in the build validation scripts which has been fixed. I re-ran this pipeline to verify the execution of the build validation scripts succeeded, but the build failed due to requiring Java 17 to build.

> AndroidX build must be invoked with JDK 17.
Make sure your JAVA_HOME environment variable points to Java 17 JDK.
Current version: 11
Current JAVA HOME: /usr/lib/jvm/temurin-11-jdk-amd64

https://github.com/gradle/gradle-enterprise-oss-projects/actions/runs/3760933731/jobs/6392160988#step:7:202