### PR TITLE
Do not fail Androidx if not fully cacheable

### DIFF
--- a/.github/workflows/run-experiments-androidx.yml
+++ b/.github/workflows/run-experiments-androidx.yml
@@ -67,7 +67,7 @@ jobs:
           args: ${{ env.ARGS }}
           projectDir: ${{ env.PROJECT_DIR }}
           gradleEnterpriseUrl: ${{ env.GRADLE_ENTERPRISE_URL }}
-          failIfNotFullyCacheable: true
+          failIfNotFullyCacheable: false
         if: matrix.experimentId == 2
       - name: Run experiment 3
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/experiment-3@actions-stable
@@ -79,5 +79,5 @@ jobs:
           args: ${{ env.ARGS }}
           projectDir: ${{ env.PROJECT_DIR }}
           gradleEnterpriseUrl: ${{ env.GRADLE_ENTERPRISE_URL }}
-          failIfNotFullyCacheable: true
+          failIfNotFullyCacheable: false
         if: matrix.experimentId == 3


### PR DESCRIPTION
:buildOnServer is getting cache misses on Experiment 2 and 3

Signed-off-by: Jerome Prinet <jprinet@gradle.com>