### PR TITLE
Upgrade actions/setup-java to v3 for Kotlin

### DIFF
--- a/.github/workflows/run-experiments-kotlin.yml
+++ b/.github/workflows/run-experiments-kotlin.yml
@@ -26,13 +26,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up JDK 6
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 6
+          distribution: "zulu"
       - name: Set up JDK 7
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 7
+          distribution: "zulu"
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/run-experiments-kotlin.yml
+++ b/.github/workflows/run-experiments-kotlin.yml
@@ -11,7 +11,7 @@ env:
   GRADLE_ENTERPRISE_URL: "https://ge.solutions-team.gradle.com"
   GIT_REPO: "https://github.com/JetBrains/kotlin"
   TASKS: "install"
-  ARGS: "-Porg.gradle.java.installations.paths=/opt/hostedtoolcache/jdk/6.X/x64,/opt/hostedtoolcache/jdk/7.X/x64 -Pkotlin.test.maxParallelForks=4"
+  ARGS: "-Pkotlin.test.maxParallelForks=4"
 
 jobs:
   Experiment:
@@ -40,16 +40,9 @@ jobs:
         with:
           java-version: 11
           distribution: "temurin"
-      - name: Add aliases to JAVA_HOME
-        run: |
-          mkdir -p /opt/hostedtoolcache/jdk
-          ln -s /opt/hostedtoolcache/Java_Zulu_jdk/6.* /opt/hostedtoolcache/jdk/6.X
-          ln -s /opt/hostedtoolcache/Java_Zulu_jdk/7.* /opt/hostedtoolcache/jdk/7.X
-        shell: bash
       - name: Display toolchain
         run: |
           touch settings.gradle
-          ls -la /opt/hostedtoolcache/jdk
           gradle -q javaToolchains ${{ env.ARGS }}
         shell: bash
       - name: Create Git hook to disable Gradle verification metadata

--- a/.github/workflows/run-experiments-kotlin.yml
+++ b/.github/workflows/run-experiments-kotlin.yml
@@ -42,8 +42,9 @@ jobs:
           distribution: "temurin"
       - name: Add aliases to JAVA_HOME
         run: |
-          ln -s /opt/hostedtoolcache/jdk/6.* /opt/hostedtoolcache/jdk/6.X
-          ln -s /opt/hostedtoolcache/jdk/7.* /opt/hostedtoolcache/jdk/7.X
+          mkdir -p /opt/hostedtoolcache/jdk
+          ln -s /opt/hostedtoolcache/Java_Zulu_jdk/6.* /opt/hostedtoolcache/jdk/6.X
+          ln -s /opt/hostedtoolcache/Java_Zulu_jdk/7.* /opt/hostedtoolcache/jdk/7.X
         shell: bash
       - name: Display toolchain
         run: |


### PR DESCRIPTION
Same as https://github.com/gradle/gradle-enterprise-oss-projects/pull/22

https://github.com/gradle/gradle-enterprise-oss-projects/actions/runs/4095840646 is full of warnings that can be fixed by this PR. `distribution:` is mandatory from `v2`.

I tried to see what different versions of setup-java download for 6 and 7, and it works fine on each:
https://github.com/TWiStErRob/github-actions-test/actions/runs/4146768966

The GHA debug log reveals the URL being downloaded:
v1: `##[debug]Downloading https://static.azul.com/zulu/bin/zulu6.22.0.3-jdk6.0.119-linux_x64.tar.gz`
v3: `##[debug]Downloading https://cdn.azul.com/zulu/bin/zulu6.22.0.3-jdk6.0.119-linux_x64.tar.gz`