### PR TITLE
Use assemble task to build spring-boot instead of systemTest

### DIFF
--- a/.github/workflows/run-experiments-spring-boot.yml
+++ b/.github/workflows/run-experiments-spring-boot.yml
@@ -10,7 +10,7 @@ on:
 env:
   GRADLE_ENTERPRISE_URL: "https://ge.solutions-team.gradle.com"
   GIT_REPO: "https://github.com/spring-projects/spring-boot"
-  TASKS: "systemTest"
+  TASKS: "assemble"
 
 jobs:
   Experiment:


### PR DESCRIPTION
Switch to assemble task as per Spring team recommendation. The systemTest task has some flaky tests.