### PR TITLE
Add JDK 9 for Kotlin

### DIFF
--- a/.github/workflows/run-experiments-kotlin.yml
+++ b/.github/workflows/run-experiments-kotlin.yml
@@ -35,6 +35,11 @@ jobs:
         with:
           java-version: 7
           distribution: "zulu"
+      - name: Set up JDK 9
+        uses: actions/setup-java@v3
+        with:
+          java-version: 9
+          distribution: "zulu"
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
JDK 9 is now required to build Kotlin:
https://github.com/JetBrains/kotlin/blob/4b524b8589afce0ea8ebef6500325b90cc1b4d15/buildSrc/src/main/kotlin/LibrariesCommon.kt#L23