### PR TITLE
Schedule Dependabot to run at 02:00 UTC each day

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,4 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      time: "02:00"


### PR DESCRIPTION
This PR sets the time that Dependabot will check for new dependencies to 02:00 UTC. This is aligned with the time that the wrapper upgrade runs. The idea is to have all version checks occur at the same time each day across all Solutions projects.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduletime