### PR TITLE
Disable caching for kotlin-dom-api-compat:compileKotlinJs

### DIFF
--- a/.github/workflows/run-experiments-kotlin.yml
+++ b/.github/workflows/run-experiments-kotlin.yml
@@ -56,6 +56,9 @@ jobs:
           echo -e "#!/bin/bash\nrm -f gradle/verification-metadata.xml\n" > ~/git-hooks/post-checkout
           chmod +x ~/git-hooks/post-checkout
           git config --global core.hooksPath ~/git-hooks
+      - name: Adjust git hook to temporarily disable caching for kotlin-dom-api-compat:compileKotlinJs (KT-56690)
+        run: |
+          echo -e 'echo "\ntasks.withType<org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile>().configureEach { outputs.doNotCacheIf(\"https://youtrack.jetbrains.com/issue/KT-56690\") { true } }" >> libraries/kotlin-dom-api-compat/build.gradle.kts\n' >> ~/git-hooks/post-checkout
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable
         with:


### PR DESCRIPTION
[KT-56690](https://youtrack.jetbrains.com/issue/KT-56690) forces to use an absolute in [the task configuration](https://github.com/JetBrains/kotlin/blob/09474758ab3fd9ea869f52dd46019e4ec417dc4e/libraries/kotlin-dom-api-compat/build.gradle.kts#L35)

We can disable caching while running the experiments to keep the `failIfNotFullyCacheable: true`

Disabling the cache in the source code directly would prevent to get local cache hit and is therefore not an option.
