### PR TITLE
Disable dependency verification by configuration

### DIFF
--- a/.github/workflows/run-experiments-androidx.yml
+++ b/.github/workflows/run-experiments-androidx.yml
@@ -12,7 +12,7 @@ env:
   GIT_REPO: "https://github.com/androidx/androidx"
   TASKS: "buildOnServer zipTestConfigsWithApks test"
   PROJECT_DIR: "biometric"
-  ARGS: "-x ktlint"
+  ARGS: "-x ktlint -Dorg.gradle.dependency.verification=off"
 
 jobs:
   Experiment:
@@ -42,12 +42,6 @@ jobs:
           distribution: "temurin"
       - name: Set up Android SDK
         uses: android-actions/setup-android@v2
-      - name: Create Git hook to disable Gradle verification metadata
-        run: |
-          mkdir ~/git-hooks
-          echo -e "#!/bin/bash\nrm -f gradle/verification-metadata.xml\n" > ~/git-hooks/post-checkout
-          chmod +x ~/git-hooks/post-checkout
-          git config --global core.hooksPath ~/git-hooks
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable
         with:

--- a/.github/workflows/run-experiments-kotlin.yml
+++ b/.github/workflows/run-experiments-kotlin.yml
@@ -11,7 +11,7 @@ env:
   GRADLE_ENTERPRISE_URL: "https://ge.solutions-team.gradle.com"
   GIT_REPO: "https://github.com/JetBrains/kotlin"
   TASKS: "install"
-  ARGS: "-Pkotlin.test.maxParallelForks=4"
+  ARGS: "-Pkotlin.test.maxParallelForks=4 -Dorg.gradle.dependency.verification=off"
 
 jobs:
   Experiment:
@@ -50,15 +50,12 @@ jobs:
           touch settings.gradle
           gradle -q javaToolchains ${{ env.ARGS }}
         shell: bash
-      - name: Create Git hook to disable Gradle verification metadata
+      - name: Add git hook to temporarily disable caching for kotlin-dom-api-compat:compileKotlinJs (KT-56690)
         run: |
           mkdir ~/git-hooks
-          echo -e "#!/bin/bash\nrm -f gradle/verification-metadata.xml\n" > ~/git-hooks/post-checkout
+          echo -e 'echo "\ntasks.withType<org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile>().configureEach { outputs.doNotCacheIf(\"https://youtrack.jetbrains.com/issue/KT-56690\") { true } }" >> libraries/kotlin-dom-api-compat/build.gradle.kts\n' > ~/git-hooks/post-checkout
           chmod +x ~/git-hooks/post-checkout
           git config --global core.hooksPath ~/git-hooks
-      - name: Adjust git hook to temporarily disable caching for kotlin-dom-api-compat:compileKotlinJs (KT-56690)
-        run: |
-          echo -e 'echo "\ntasks.withType<org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile>().configureEach { outputs.doNotCacheIf(\"https://youtrack.jetbrains.com/issue/KT-56690\") { true } }" >> libraries/kotlin-dom-api-compat/build.gradle.kts\n' >> ~/git-hooks/post-checkout
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable
         with:


### PR DESCRIPTION
Use the [proper way](https://docs.gradle.org/current/userguide/dependency_verification.html#sec:disabling-verification) to disable it instead of a Git hook

Thanks @clayburn for spotting this 👍