### PR TITLE
Add Calcite workflow

### DIFF
--- a/.github/workflows/run-experiments-calcite.yml
+++ b/.github/workflows/run-experiments-calcite.yml
@@ -1,0 +1,65 @@
+name: Calcite
+
+on:
+  schedule:
+    # Every Sunday at 9.30am
+    - cron: "30 9 * * 0"
+
+  workflow_dispatch:
+
+env:
+  GRADLE_ENTERPRISE_URL: "https://ge.solutions-team.gradle.com"
+  GIT_REPO: "https://github.com/apache/calcite"
+  TASKS: "build"
+  GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx1024m" -XX:MaxMetaspaceSize="512m" # This was seen in one of their CI jobs
+
+jobs:
+  Experiment:
+
+    strategy:
+      matrix:
+        include:
+          - experimentId: 1
+          - experimentId: 2
+          - experimentId: 3
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: "temurin"
+      - name: Download latest version of the validation scripts
+        uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run experiment 1
+        uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: "${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}"
+        with:
+          gitRepo: ${{ env.GIT_REPO }}
+          tasks: ${{ env.TASKS }}
+          gradleEnterpriseUrl: ${{ env.GRADLE_ENTERPRISE_URL }}
+        if: matrix.experimentId == 1
+      - name: Run experiment 2
+        uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/experiment-2@actions-stable
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: "${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}"
+        with:
+          gitRepo: ${{ env.GIT_REPO }}
+          tasks: ${{ env.TASKS }}
+          gradleEnterpriseUrl: ${{ env.GRADLE_ENTERPRISE_URL }}
+          failIfNotFullyCacheable: true # Require no issues to be found
+        if: matrix.experimentId == 2
+      - name: Run experiment 3
+        uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/experiment-3@actions-stable
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: "${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}"
+        with:
+          gitRepo: ${{ env.GIT_REPO }}
+          tasks: ${{ env.TASKS }}
+          gradleEnterpriseUrl: ${{ env.GRADLE_ENTERPRISE_URL }}
+          failIfNotFullyCacheable: true # Require no issues to be found
+        if: matrix.experimentId == 3

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The following OSS projects currently benefit from enhanced developer productivit
 - [Apollo](https://ge.apollographql.com)
 - [Armeria](https://ge.armeria.dev)
 - [Caffeine](https://caffeine.gradle-enterprise.cloud)
+- [Calcite](https://ge.apache.org)
 - [Detekt](https://ge.detekt.dev)
 - [Gradle](https://ge.gradle.org)
 - [Grails](https://ge.grails.org)


### PR DESCRIPTION
I've tested the workflow against my POC GE instance - screenshots below. Got the Calcite GE server from their settings file:
https://github.com/apache/calcite/blob/main/settings.gradle.kts#L109

--
![Screenshot 2023-06-29 at 7 17 45 PM](https://github.com/gradle/gradle-enterprise-oss-projects/assets/120980/54bb74b0-7e21-4b0d-ab27-711510193972)
--
![Screenshot 2023-06-29 at 7 06 31 PM](https://github.com/gradle/gradle-enterprise-oss-projects/assets/120980/795474ae-66c6-4505-a1b7-cbdf5ffa3985)
--
![Screenshot 2023-06-29 at 7 06 39 PM](https://github.com/gradle/gradle-enterprise-oss-projects/assets/120980/6518688a-4c68-40bc-b558-0e4834b50803)
--
![Screenshot 2023-06-29 at 7 07 39 PM](https://github.com/gradle/gradle-enterprise-oss-projects/assets/120980/589637ed-12e2-4ac7-92d0-8e438853e7f6)
--
![Screenshot 2023-06-29 at 7 07 54 PM](https://github.com/gradle/gradle-enterprise-oss-projects/assets/120980/87a763e7-4d62-4f83-89d5-516b59982ebc)