### PR TITLE
Run build task for Spring Framework

### DIFF
--- a/.github/workflows/run-experiments-spring-framework.yml
+++ b/.github/workflows/run-experiments-spring-framework.yml
@@ -10,7 +10,7 @@ on:
 env:
   GRADLE_ENTERPRISE_URL: "https://ge.solutions-team.gradle.com"
   GIT_REPO: "https://github.com/spring-projects/spring-framework"
-  TASKS: "assemble"
+  TASKS: "build"
 
 jobs:
   Experiment:


### PR DESCRIPTION
Now that [the absolute path issue with `runtimeHintsTest` has been merged](https://github.com/spring-projects/spring-framework/pull/30838), we can set this workflow to use the `build` task.

See this successful run on my fork: https://github.com/erichaagdev/gradle-enterprise-oss-projects/actions/runs/5509886501