### PR TITLE
Disable PTS on Detekt build to ensure Test task cacheability

### DIFF
--- a/.github/workflows/run-experiments-detekt.yml
+++ b/.github/workflows/run-experiments-detekt.yml
@@ -10,7 +10,7 @@ on:
 env:
   GRADLE_ENTERPRISE_URL: "https://ge.solutions-team.gradle.com"
   GIT_REPO: "https://github.com/detekt/detekt"
-  TASKS: "build -x detekt"
+  TASKS: "build -x detekt -PenablePTS=false"
 
 jobs:
   Experiment:
@@ -50,7 +50,7 @@ jobs:
           gitRepo: ${{ env.GIT_REPO }}
           tasks: ${{ env.TASKS }}
           gradleEnterpriseUrl: ${{ env.GRADLE_ENTERPRISE_URL }}
-          failIfNotFullyCacheable: false
+          failIfNotFullyCacheable: true
         if: matrix.experimentId == 2
       - name: Run experiment 3
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/experiment-3@actions-stable
@@ -60,5 +60,5 @@ jobs:
           gitRepo: ${{ env.GIT_REPO }}
           tasks: ${{ env.TASKS }}
           gradleEnterpriseUrl: ${{ env.GRADLE_ENTERPRISE_URL }}
-          failIfNotFullyCacheable: false
+          failIfNotFullyCacheable: true
         if: matrix.experimentId == 3


### PR DESCRIPTION
### Issue
the Test task of the detekt project is not always cached due to PTS not selecting all tests

### Fix
Disable PTS by configuring [enablePTS](https://github.com/detekt/detekt/blob/b3915a4de6a545d7d2b42e817ef8d93a5017aa95/build.gradle.kts#L70) property