### PR TITLE
Handle Apollo Cache Misses

### DIFF
--- a/.github/workflows/run-experiments-apollo.yml
+++ b/.github/workflows/run-experiments-apollo.yml
@@ -29,10 +29,20 @@ jobs:
         with:
           java-version: 17
           distribution: "temurin"
+      - name: Add git hook to temporarily disable caching for :intellij-plugin:instrumentCode
+        run: |
+          mkdir ~/git-hooks
+          echo -e 'echo "\ntasks.withType<org.jetbrains.intellij.tasks.InstrumentCodeTask>().configureEach { outputs.doNotCacheIf(\"https://github.com/JetBrains/gradle-intellij-plugin/issues/1426\") { true } }" >> intellij-plugin/build.gradle.kts\n' >> ~/git-hooks/post-checkout
+          echo -e 'echo "\ntasks.withType<org.jetbrains.intellij.tasks.BuildPluginTask>().configureEach { outputs.doNotCacheIf(\"buildPlugin should not be cacheable as it is a Zip task\") { true } }" >> intellij-plugin/build.gradle.kts\n' >> ~/git-hooks/post-checkout
+          echo -e 'echo "\nsubprojects { tasks.withType<org.jetbrains.dokka.gradle.DokkaTask>().configureEach { outputs.doNotCacheIf(\"https://github.com/Kotlin/dokka/issues/2978\") { true } } }" >> build.gradle.kts\n' >> ~/git-hooks/post-checkout
+          chmod +x ~/git-hooks/post-checkout
+          git config --global core.hooksPath ~/git-hooks
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Increase timeout when retrieving build scans
+        run: echo 'connect.timeout=PT90S' >> gradle-enterprise-gradle-build-validation/network.settings && echo 'read.timeout=PT90S' >> gradle-enterprise-gradle-build-validation/network.settings
       - name: Run experiment 1
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable
         env:


### PR DESCRIPTION
1. Makes `InstrumentCodeTask` task not cacheable for the experiment executions - `ideaDependency` may be improperly authored, and `InstrumentCodeTask` is not reliably cacheable in CI because of it. This cache miss is currently under investigation, but is proving to be time-consuming.
2. Makes `BuildPluginTask` task not cacheable for the experiment executions - `BuildPluginTask` should not be cacheable because it is a `Zip` task. [The GitHub issue](https://github.com/JetBrains/gradle-intellij-plugin/issues/1426) has been resolved, but not yet released
3. Make `DokkaTask` not cacheable for the experiment executions - `DokkaTask` has an [unresolved issue](https://github.com/Kotlin/dokka/issues/2978) to make it cacheable

Fixes failure to retrieve performance metrics from GE by raising network timeout for Apollo experiments