### PR TITLE
Apache Solr - Mark SpotlessTaskImpl Not Cacheable

### DIFF
--- a/.github/workflows/run-experiments-apache-solr.yml
+++ b/.github/workflows/run-experiments-apache-solr.yml
@@ -10,7 +10,7 @@ on:
 env:
   GRADLE_ENTERPRISE_URL: "https://ge.solutions-team.gradle.com"
   GIT_REPO: "https://github.com/apache/solr"
-  TASKS: "check integrationTests -Ptests.seed=3466BEBDD5AA01A0 -Pvalidation.git.failOnModified=false -Ptests.haltonfailure=false"
+  TASKS: "check integrationTests -Ptests.seed=3466BEBDD5AA01A0 -Pvalidation.git.failOnModified=false -Ptests.haltonfailure=false -Ptests.neverUpToDate=false"
 
 jobs:
   Experiment:

--- a/.github/workflows/run-experiments-apache-solr.yml
+++ b/.github/workflows/run-experiments-apache-solr.yml
@@ -29,6 +29,12 @@ jobs:
         with:
           java-version: 17
           distribution: "temurin"
+      - name: Add git hook to temporarily disable caching for SpotlessTaskImpl tasks
+        run: |
+          mkdir ~/git-hooks
+          echo -e 'echo "\nallprojects { pluginManager.withPlugin(\"com.diffplug.spotless\") { tasks.withType(com.diffplug.gradle.spotless.SpotlessTaskImpl).configureEach { outputs.doNotCacheIf(\"SpotlessTaskImpl is not cacheable if custom formatter steps are used\") { true } } } }" >> build.gradle\n' >> ~/git-hooks/post-checkout
+          chmod +x ~/git-hooks/post-checkout
+          git config --global core.hooksPath ~/git-hooks
       - name: Download latest version of the validation scripts
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable
         with:


### PR DESCRIPTION
* Marks `SpotlessTaskImpl` as not cacheable for the purposes of these experiments
* Applies `tests.neverUpToDate=false` to ensure that the cacheability of test tasks is tested by the experiments