### PR TITLE
Ignore flakiness in :detekt-gradle-plugin:functionalTest

### DIFF
--- a/.github/workflows/run-experiments-detekt.yml
+++ b/.github/workflows/run-experiments-detekt.yml
@@ -10,7 +10,7 @@ on:
 env:
   GRADLE_ENTERPRISE_URL: "https://ge.solutions-team.gradle.com"
   GIT_REPO: "https://github.com/detekt/detekt"
-  TASKS: "build -x detekt -PenablePTS=false"
+  TASKS: "build -x detekt -x :detekt-gradle-plugin:functionalTest -PenablePTS=false"
 
 jobs:
   Experiment:


### PR DESCRIPTION
### Issue
Detekt build is failing very often due to test failures in `:detekt-gradle-plugin:functionalTest`
See failure trends [here](https://ge.solutions-team.gradle.com/scans/failures?failures.failureClassification=all_failures&failures.failureMessage=Execution%20failed%20for%20task%20*%0A%3E%20There%20were%20failing%20tests.%20See%20the%20report%20at:%20file:%2F%2F%2F*%2F*%2F*%2F*%2Fbuild%2Freports%2Ftests%2F*%2Findex.html&search.query=project:detekt&search.relativeStartTime=P90D&search.timeZoneId=Europe%2FParis)

This issue has been fixed on _Detekt_ by publishing the artifact to local repository.
See PR [here](https://github.com/detekt/detekt/pull/6424)
The fix consist of a 2 step build to publish first the artifacts in the local Maven repository.

Trying it in the experiments with a single invocation still fails
`./gradlew publishToMavenLocal build -x detekt`

### Fix
Ignore the failing task
