### PR TITLE
Skip japiCmp task execution in Micronaut build

### DIFF
--- a/.github/workflows/run-experiments-micronaut.yml
+++ b/.github/workflows/run-experiments-micronaut.yml
@@ -11,7 +11,7 @@ env:
   GRADLE_ENTERPRISE_URL: "https://ge.solutions-team.gradle.com"
   GIT_REPO: "https://github.com/micronaut-projects/micronaut-core"
   TASKS: "check"
-  ARGS: "-x :http-client:test -x :inject:test"
+  ARGS: "-x :http-client:test -x :inject:test -x japiCmp"
 
 jobs:
   Experiment:


### PR DESCRIPTION
### Issue
japiCmp is having cache misses due to rules containing absolute paths.
See example [here](https://ge.solutions-team.gradle.com/s/h6cg3lil4gpdo/timeline?cacheability=cacheable&outcome=success)

Decision was taken not to fix those for the moment.
See closed PR [here](https://github.com/melix/japicmp-gradle-plugin/pull/66)

In addition, japiCmp task is failing often.
See failure trends [here](https://ge.solutions-team.gradle.com/scans/failures?failures.failureClassification=all_failures&failures.failureMessage=Execution%20failed%20for%20task%20%27:inject-groovy:japiCmp%27.%0A%3E%20A%20failure%20occurred%20while%20executing%20me.champeau.gradle.japicmp.JApiCmpWorkAction%0A%20%20%20%3E%20Detected%20binary%20changes.%0A%20%20%20%20%20%20%20%20%20-%20current:%20inject-groovy-4.2.0-SNAPSHOT.jar%0A%20%20%20%20%20%20%20%20%20-%20baseline:%20*%0A%20%20%20%20%20%0A%20%20%20%20%20See%20failure%20report%20at%20file:%2F%2F%2F*%2F*%2F*%2F*%2F*%2Fgradle-enterprise-gradle-build-validation%2F.data%2F02-validate-local-build-caching-same-location%2F*%2Fbuild_micronaut-core%2Finject-groovy%2Fbuild%2Freports%2Fbinary-compatibility-inject-groovy.html&search.relativeStartTime=P90D&search.timeZoneId=Europe%2FParis)

### Fix
Exclude task from experiment builds