### PR TITLE
Ignore Androidx cache misses on :biometric:integration-tests:testapp

### DIFF
--- a/.github/workflows/run-experiments-androidx.yml
+++ b/.github/workflows/run-experiments-androidx.yml
@@ -46,6 +46,17 @@ jobs:
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/download@actions-stable
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+      # MergeResources and DataBindingGenBaseClassesTask are not cache relocatable when resourceDirsOutsideRootProjectDir is not empty
+      # https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:build-system/gradle-core/src/main/java/com/android/build/gradle/tasks/MergeResources.kt;l=164?q=MergeResources
+      # This is the case here as androidx/biometric project has its root dir set to androidx/playground-projects/biometric-playground
+      - name: Adjust git hook to temporarily disable caching for MergeResources and DataBindingGenBaseClassesTask on biometric:integration-tests
+        run: |
+          mkdir ~/git-hooks
+          echo -e 'echo "\nproject.getTasks().withType(com.android.build.gradle.tasks.MergeResources).configureEach { outputs.doNotCacheIf(\"MergeResources is not cache relocatable when resourceDirsOutsideRootProjectDir is not empty\") { true } }" >> biometric/integration-tests/testapp/build.gradle\n' > ~/git-hooks/post-checkout
+          echo -e 'echo "\nproject.getTasks().withType(com.android.build.gradle.internal.tasks.databinding.DataBindingGenBaseClassesTask).configureEach { outputs.doNotCacheIf(\"DataBindingGenBaseClassesTask is not cache relocatable when resourceDirsOutsideRootProjectDir is not empty\") { true } }" >> biometric/integration-tests/testapp/build.gradle\n' >> ~/git-hooks/post-checkout
+          chmod +x ~/git-hooks/post-checkout
+          git config --global core.hooksPath ~/git-hooks
+        if: matrix.experimentId == 3
       - name: Run experiment 1
         uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/gradle/experiment-1@actions-stable
         env:


### PR DESCRIPTION
### Issue
Androidx has some new [cache misses](https://ge.solutions-team.gradle.com/s/dcu3wywvihufu/timeline?cacheability=cacheable&outcome=success) on experiment 3 

### Reason
The [Build Scan comparison](https://ge.solutions-team.gradle.com/c/dcu3wywvihufu/hsgtxqg2i2eoi/task-inputs?cacheability=cacheable) shows that `MergeResources.resourceDirsOutsideRootProjectDir` is the changing input

The [code](https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:build-system/gradle-core/src/main/java/com/android/build/gradle/tasks/MergeResources.kt;l=163?q=getResourcesDirsOutsideRoot) documents that this property will make the task not relocatable when not empty with [view binding enabled](https://github.com/androidx/androidx/blob/51779ac680d474c4d5713b3c80a2cc492bbadf5c/biometric/integration-tests/testapp/build.gradle#L45).

Interestingly enough, since [this commit](https://github.com/androidx/androidx/commit/32794457fdcdcdca6f1f92579be76723e7a2601c) the resourceDir and the rootDir differs [making the property not empty](https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:build-system/gradle-core/src/main/java/com/android/build/gradle/tasks/MergeResources.kt;l=974?q=getResourcesDirsOutsideRoot) with absolute paths.

### Fix
Make the tasks not cacheable with a Git hook