### PR TITLE
Upgrade XWiki to JDK 17 and MVN 3.9.6 as per project requirements

### DIFF
--- a/.github/workflows/run-experiments-xwiki.yml
+++ b/.github/workflows/run-experiments-xwiki.yml
@@ -24,11 +24,13 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - name: Set up JDK 11
-        uses: actions/setup-java@v4
+      - name: Setup Maven Action
+        uses: s4u/setup-maven-action@v1.11.0
         with:
-          java-version: 11
-          distribution: "temurin"
+          checkout-fetch-depth: 0
+          java-version: 17
+          java-distribution: temurin
+          maven-version: 3.9.6
       - name: Configure Maven settings
         run: >
           echo '<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"


### PR DESCRIPTION
### Issue
Xwiki build is currently failing because
- JDK 17 is required
- mvn 3.9.6 is required not to be exposed to [this](https://issues.apache.org/jira/browse/MENFORCER-473)

### Fix
Use [setup-maven-action](https://github.com/marketplace/actions/setup-maven-action) to address both requirements