### PR TITLE
Fix Kotlin Build Scan publication

### DIFF
--- a/.github/workflows/run-experiments-kotlin.yml
+++ b/.github/workflows/run-experiments-kotlin.yml
@@ -10,7 +10,7 @@ env:
   DEVELOCITY_URL: "https://ge.solutions-team.gradle.com"
   GIT_REPO: "https://github.com/JetBrains/kotlin"
   TASKS: "install"
-  ARGS: "-Pkotlin.test.maxParallelForks=4 -Dorg.gradle.dependency.verification=off"
+  ARGS: "-Pkotlin.test.maxParallelForks=4 -Dorg.gradle.dependency.verification=off -Pkotlin.build.scan.url=https://ge.solutions-team.gradle.com"
 
 jobs:
   Experiment:


### PR DESCRIPTION
The Kotlin Build Scan publication is not happening since probably [this change](https://github.com/JetBrains/kotlin/commit/f29dbebc6658ec0e598e1a1a32b1ec4c5e8720c0#diff-a509f099568f829f6afadb08b7a8bb5cec36695ee5709858e37ca3edfab71887R24).

The publication can be enabled by configuring the project property `kotlin.build.scan.url`
