### PR TITLE
Deleted ge.hibernate.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ The following OSS projects currently benefit from enhanced developer productivit
 - [Detekt](https://ge.detekt.dev)
 - [Gradle](https://ge.gradle.org)
 - [Grails](https://ge.grails.org)
-- [Hibernate](https://ge.hibernate.org)
 - [JHipster](https://ge.jhipster.tech)
 - [JUnit](https://ge.junit.org)
 - [Kotlin](https://ge.jetbrains.com)


### PR DESCRIPTION
Hibernate has been moved to the Commonhaus Foundation ([announcement](https://in.relation.to/2024/04/09/hibernate-to-commonhaus/)).