### PR TITLE
Fix failures in Micronaut and Apereo CAS experiments

### DIFF
--- a/.github/workflows/run-experiments-apereo-cas.yml
+++ b/.github/workflows/run-experiments-apereo-cas.yml
@@ -16,7 +16,6 @@ env:
   GIT_REPO: "https://github.com/apereo/cas"
   # Exclude cas-server-core-scripting:testGroovy (Groovy scripting tests fail upstream).
   TASKS: "build testCAS testLogout testGroovy testTickets -x check -x :core:cas-server-core-scripting:testGroovy"
-  ARGS: "--no-configuration-cache"
 
 jobs:
   Experiment:
@@ -47,7 +46,6 @@ jobs:
         with:
           gitRepo: ${{ env.GIT_REPO }}
           tasks: ${{ env.TASKS }}
-          args: ${{ env.ARGS }}
           develocityUrl: ${{ env.DEVELOCITY_URL }}
         if: matrix.experimentId == 1
       - name: Run experiment 2
@@ -57,7 +55,6 @@ jobs:
         with:
           gitRepo: ${{ env.GIT_REPO }}
           tasks: ${{ env.TASKS }}
-          args: ${{ env.ARGS }}
           develocityUrl: ${{ env.DEVELOCITY_URL }}
           failIfNotFullyCacheable: true
         if: matrix.experimentId == 2
@@ -68,7 +65,6 @@ jobs:
         with:
           gitRepo: ${{ env.GIT_REPO }}
           tasks: ${{ env.TASKS }}
-          args: ${{ env.ARGS }}
           develocityUrl: ${{ env.DEVELOCITY_URL }}
           failIfNotFullyCacheable: true
         if: matrix.experimentId == 3

--- a/.github/workflows/run-experiments-micronaut-core.yml
+++ b/.github/workflows/run-experiments-micronaut-core.yml
@@ -28,10 +28,10 @@ jobs:
           - experimentId: 3
     runs-on: ubuntu-latest
     steps:
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
-          java-version: 21
+          java-version: 25
           distribution: "temurin"
       - name: Download latest version of the validation scripts
         uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/download@actions-stable

--- a/.github/workflows/run-experiments-micronaut-data.yml
+++ b/.github/workflows/run-experiments-micronaut-data.yml
@@ -27,10 +27,10 @@ jobs:
           - experimentId: 3
     runs-on: ubuntu-latest
     steps:
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
-          java-version: 21
+          java-version: 25
           distribution: "temurin"
       - name: Download latest version of the validation scripts
         uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/download@actions-stable

--- a/.github/workflows/run-experiments-micronaut-kafka.yml
+++ b/.github/workflows/run-experiments-micronaut-kafka.yml
@@ -27,10 +27,10 @@ jobs:
           - experimentId: 3
     runs-on: ubuntu-latest
     steps:
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
-          java-version: 21
+          java-version: 25
           distribution: "temurin"
       - name: Download latest version of the validation scripts
         uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/download@actions-stable

--- a/.github/workflows/run-experiments-micronaut-kotlin.yml
+++ b/.github/workflows/run-experiments-micronaut-kotlin.yml
@@ -27,10 +27,10 @@ jobs:
           - experimentId: 3
     runs-on: ubuntu-latest
     steps:
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
-          java-version: 21
+          java-version: 25
           distribution: "temurin"
       - name: Download latest version of the validation scripts
         uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/download@actions-stable

--- a/.github/workflows/run-experiments-micronaut-security.yml
+++ b/.github/workflows/run-experiments-micronaut-security.yml
@@ -28,10 +28,10 @@ jobs:
           - experimentId: 3
     runs-on: ubuntu-latest
     steps:
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
-          java-version: 21
+          java-version: 25
           distribution: "temurin"
       - name: Download latest version of the validation scripts
         uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/download@actions-stable

--- a/.github/workflows/run-experiments-micronaut-spring.yml
+++ b/.github/workflows/run-experiments-micronaut-spring.yml
@@ -31,10 +31,10 @@ jobs:
           - experimentId: 3
     runs-on: ubuntu-latest
     steps:
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
-          java-version: 21
+          java-version: 25
           distribution: "temurin"
       - name: Download latest version of the validation scripts
         uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/download@actions-stable

--- a/.github/workflows/run-experiments-micronaut-starter.yml
+++ b/.github/workflows/run-experiments-micronaut-starter.yml
@@ -27,10 +27,10 @@ jobs:
           - experimentId: 3
     runs-on: ubuntu-latest
     steps:
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
-          java-version: 21
+          java-version: 25
           distribution: "graalvm"
       - name: Download latest version of the validation scripts
         uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/download@actions-stable


### PR DESCRIPTION
Two config fixes on our side for currently-red experiment workflows.

Micronaut (core, data, kafka, kotlin, security, spring, starter): bump pinned JDK 21 to 25. Upstream now requires JDK 25 to resolve micronaut-gradle-plugins, so these died before any experiment ran. Micronaut AWS already runs JDK 25 and is green. Starter keeps the graalvm distribution.

Apereo CAS: stop passing --no-configuration-cache. CAS now enables Isolated Projects, which requires the configuration cache, so all three experiments failed immediately with "Configuration Cache cannot be disabled when Isolated Projects is enabled."