### PR TITLE
Remove push trigger from experiment workflows

### DIFF
--- a/.github/workflows/run-experiments-androidx.yml
+++ b/.github/workflows/run-experiments-androidx.yml
@@ -1,9 +1,6 @@
 name: AndroidX Biometric
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-androidx.yml'
   schedule:
     - cron: "0 8 * * 4"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-apache-beam.yml
+++ b/.github/workflows/run-experiments-apache-beam.yml
@@ -1,9 +1,6 @@
 name: Apache Beam
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-apache-beam.yml'
   schedule:
     - cron: "0 4 * * 6"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-apache-calcite.yml
+++ b/.github/workflows/run-experiments-apache-calcite.yml
@@ -1,9 +1,6 @@
 name: Apache Calcite
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-apache-calcite.yml'
   schedule:
     - cron: "0 19 * * 4"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-apache-geode.yml
+++ b/.github/workflows/run-experiments-apache-geode.yml
@@ -1,9 +1,6 @@
 name: Apache Geode
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-apache-geode.yml'
   schedule:
     - cron: "0 3 * * 6"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-apache-groovy.yml
+++ b/.github/workflows/run-experiments-apache-groovy.yml
@@ -1,9 +1,6 @@
 name: Apache Groovy
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-apache-groovy.yml'
   schedule:
     - cron: "0 11 * * 5"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-apache-james.yml
+++ b/.github/workflows/run-experiments-apache-james.yml
@@ -1,9 +1,6 @@
 name: Apache James
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-apache-james.yml'
   schedule:
     - cron: "0 20 * * 4"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-apache-jmeter.yml
+++ b/.github/workflows/run-experiments-apache-jmeter.yml
@@ -1,9 +1,6 @@
 name: Apache JMeter
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-apache-jmeter.yml'
   schedule:
     - cron: "0 10 * * 4"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-apache-kafka.yml
+++ b/.github/workflows/run-experiments-apache-kafka.yml
@@ -1,9 +1,6 @@
 name: Apache Kafka
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-apache-kafka.yml'
   schedule:
     - cron: "0 12 * * 4"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-apache-lucene.yml
+++ b/.github/workflows/run-experiments-apache-lucene.yml
@@ -1,9 +1,6 @@
 name: Apache Lucene
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-apache-lucene.yml'
   schedule:
     - cron: "0 22 * * 4"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-apache-ofbiz.yml
+++ b/.github/workflows/run-experiments-apache-ofbiz.yml
@@ -1,9 +1,6 @@
 name: Apache OFBiz
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-apache-ofbiz.yml'
   schedule:
     - cron: "0 15 * * 4"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-apache-samza.yml
+++ b/.github/workflows/run-experiments-apache-samza.yml
@@ -1,9 +1,6 @@
 name: Apache Samza
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-apache-samza.yml'
   # Schedule execution disabled while their setup is not updated and pushing scans. See https://github.com/apache/samza/pull/1718
   workflow_dispatch:
 

--- a/.github/workflows/run-experiments-apache-scimple.yml
+++ b/.github/workflows/run-experiments-apache-scimple.yml
@@ -1,9 +1,6 @@
 name: Apache SCIMple
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-apache-scimple.yml'
   schedule:
     - cron: "0 19 * * 6"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-apereo-cas.yml
+++ b/.github/workflows/run-experiments-apereo-cas.yml
@@ -1,9 +1,6 @@
 name: Apereo CAS
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-apereo-cas.yml'
   schedule:
     - cron: "0 7 * * 4"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-apollo-kotlin.yml
+++ b/.github/workflows/run-experiments-apollo-kotlin.yml
@@ -1,9 +1,6 @@
 name: Apollo Kotlin
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-apollo-kotlin.yml'
   schedule:
     - cron: "0 13 * * 4"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-armeria.yml
+++ b/.github/workflows/run-experiments-armeria.yml
@@ -1,9 +1,6 @@
 name: Armeria
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-armeria.yml'
   schedule:
     - cron: "0 2 * * 5"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-caffeine.yml
+++ b/.github/workflows/run-experiments-caffeine.yml
@@ -1,9 +1,6 @@
 name: Caffeine
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-caffeine.yml'
   schedule:
     - cron: "0 9 * * 5"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-detekt.yml
+++ b/.github/workflows/run-experiments-detekt.yml
@@ -1,9 +1,6 @@
 name: Detekt
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-detekt.yml'
   schedule:
     - cron: "0 1 * * 4"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-gradle.yml
+++ b/.github/workflows/run-experiments-gradle.yml
@@ -1,9 +1,6 @@
 name: Gradle
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-gradle.yml'
   schedule:
     - cron: "0 18 * * 4"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-grails-core.yml
+++ b/.github/workflows/run-experiments-grails-core.yml
@@ -1,9 +1,6 @@
 name: Grails Core
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-grails-core.yml'
   schedule:
     - cron: "0 17 * * 4"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-hibernate-orm.yml
+++ b/.github/workflows/run-experiments-hibernate-orm.yml
@@ -1,9 +1,6 @@
 name: Hibernate ORM
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-hibernate-orm.yml'
   schedule:
     - cron: "0 13 * * 5"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-hibernate-search.yml
+++ b/.github/workflows/run-experiments-hibernate-search.yml
@@ -1,9 +1,6 @@
 name: Hibernate Search
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-hibernate-search.yml'
   schedule:
     - cron: "0 3 * * 4"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-junit5.yml
+++ b/.github/workflows/run-experiments-junit5.yml
@@ -1,9 +1,6 @@
 name: JUnit5
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-junit5.yml'
   schedule:
     - cron: "0 10 * * 5"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-kotlin.yml
+++ b/.github/workflows/run-experiments-kotlin.yml
@@ -1,9 +1,6 @@
 name: Kotlin
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-kotlin.yml'
   schedule:
     - cron: "0 9 * * 4"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-micrometer.yml
+++ b/.github/workflows/run-experiments-micrometer.yml
@@ -1,9 +1,6 @@
 name: Micrometer
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-micrometer.yml'
   schedule:
     - cron: "0 22 * * 5"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-micronaut-aws.yml
+++ b/.github/workflows/run-experiments-micronaut-aws.yml
@@ -1,9 +1,6 @@
 name: Micronaut AWS
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-micronaut-aws.yml'
   schedule:
     - cron: "0 20 * * 5"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-micronaut-core.yml
+++ b/.github/workflows/run-experiments-micronaut-core.yml
@@ -1,9 +1,6 @@
 name: Micronaut Core
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-micronaut-core.yml'
   schedule:
     - cron: "0 16 * * 4"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-micronaut-data.yml
+++ b/.github/workflows/run-experiments-micronaut-data.yml
@@ -1,9 +1,6 @@
 name: Micronaut Data
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-micronaut-data.yml'
   schedule:
     - cron: "0 2 * * 4"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-micronaut-kafka.yml
+++ b/.github/workflows/run-experiments-micronaut-kafka.yml
@@ -1,9 +1,6 @@
 name: Micronaut Kafka
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-micronaut-kafka.yml'
   schedule:
     - cron: "0 1 * * 5"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-micronaut-kotlin.yml
+++ b/.github/workflows/run-experiments-micronaut-kotlin.yml
@@ -1,9 +1,6 @@
 name: Micronaut Kotlin
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-micronaut-kotlin.yml'
   schedule:
     - cron: "0 0 * * 5"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-micronaut-security.yml
+++ b/.github/workflows/run-experiments-micronaut-security.yml
@@ -1,9 +1,6 @@
 name: Micronaut Security
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-micronaut-security.yml'
   schedule:
     - cron: "0 5 * * 4"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-micronaut-spring.yml
+++ b/.github/workflows/run-experiments-micronaut-spring.yml
@@ -1,9 +1,6 @@
 name: Micronaut Spring
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-micronaut-spring.yml'
   schedule:
     - cron: "0 2 * * 6"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-micronaut-starter.yml
+++ b/.github/workflows/run-experiments-micronaut-starter.yml
@@ -1,9 +1,6 @@
 name: Micronaut Starter
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-micronaut-starter.yml'
   schedule:
     - cron: "0 6 * * 5"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-morphia.yml
+++ b/.github/workflows/run-experiments-morphia.yml
@@ -1,9 +1,6 @@
 name: Morphia
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-morphia.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/run-experiments-openapi-generator.yml
+++ b/.github/workflows/run-experiments-openapi-generator.yml
@@ -1,9 +1,6 @@
 name: OpenAPI Generator
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-openapi-generator.yml'
   schedule:
     - cron: "0 7 * * 5"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-openrewrite-spring.yml
+++ b/.github/workflows/run-experiments-openrewrite-spring.yml
@@ -1,9 +1,6 @@
 name: OpenRewrite Spring
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-openrewrite-spring.yml'
   schedule:
     - cron: "0 23 * * 3"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-openrewrite.yml
+++ b/.github/workflows/run-experiments-openrewrite.yml
@@ -1,9 +1,6 @@
 name: OpenRewrite
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-openrewrite.yml'
   schedule:
     - cron: "0 4 * * 5"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-quarkus.yml
+++ b/.github/workflows/run-experiments-quarkus.yml
@@ -1,9 +1,6 @@
 name: Quarkus
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-quarkus.yml'
   schedule:
     # Every Sunday at 6.00pm
     - cron: "0 18 * * 0"

--- a/.github/workflows/run-experiments-spock.yml
+++ b/.github/workflows/run-experiments-spock.yml
@@ -1,9 +1,6 @@
 name: Spock
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-spock.yml'
   schedule:
     - cron: "0 15 * * 5"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-spring-amqp.yml
+++ b/.github/workflows/run-experiments-spring-amqp.yml
@@ -1,9 +1,6 @@
 name: Spring AMQP
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-spring-amqp.yml'
   schedule:
     - cron: "0 4 * * 4"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-spring-authorization-server.yml
+++ b/.github/workflows/run-experiments-spring-authorization-server.yml
@@ -1,9 +1,6 @@
 name: Spring Authorization Server
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-spring-authorization-server.yml'
   schedule:
     - cron: "0 21 * * 5"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-spring-boot.yml
+++ b/.github/workflows/run-experiments-spring-boot.yml
@@ -1,9 +1,6 @@
 name: Spring Boot
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-spring-boot.yml'
   schedule:
     - cron: "0 23 * * 5"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-spring-framework.yml
+++ b/.github/workflows/run-experiments-spring-framework.yml
@@ -1,9 +1,6 @@
 name: Spring Framework
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-spring-framework.yml'
   schedule:
     - cron: "0 21 * * 4"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-spring-kafka.yml
+++ b/.github/workflows/run-experiments-spring-kafka.yml
@@ -1,9 +1,6 @@
 name: Spring Kafka
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-spring-kafka.yml'
   schedule:
     - cron: "0 3 * * 5"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-spring-security.yml
+++ b/.github/workflows/run-experiments-spring-security.yml
@@ -1,9 +1,6 @@
 name: Spring Security
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-spring-security.yml'
   schedule:
     - cron: "0 0 * * 6"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-testcontainers.yml
+++ b/.github/workflows/run-experiments-testcontainers.yml
@@ -1,9 +1,6 @@
 name: Testcontainers Java
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-testcontainers.yml'
   schedule:
     - cron: "0 5 * * 5"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-wrapper-upgrade-gradle-plugin.yml
+++ b/.github/workflows/run-experiments-wrapper-upgrade-gradle-plugin.yml
@@ -1,9 +1,6 @@
 name: Wrapper Upgrade Gradle Plugin
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-wrapper-upgrade-gradle-plugin.yml'
   schedule:
     - cron: "0 12 * * 5"
   workflow_dispatch:

--- a/.github/workflows/run-experiments-xwiki.yml
+++ b/.github/workflows/run-experiments-xwiki.yml
@@ -1,9 +1,6 @@
 name: XWiki Commons
 
 on:
-  push:
-    paths:
-      - '.github/workflows/run-experiments-xwiki.yml'
   schedule:
     - cron: "0 17 * * 5"
   workflow_dispatch:


### PR DESCRIPTION
The push trigger fired on any branch whose commit touched an experiment workflow file. A Renovate or Dependabot PR that re-pins a common action like setup-java touches all ~50 workflows at once, so every experiment runs on the bot branch and again on main after merge. Many fail for reasons unrelated to the change, such as cache misses, which block Renovate auto-merge and burn compute.