### PR TITLE
Migrate Testcontainers and OpenAPI Generator links to community Develocity instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ The following OSS projects currently benefit from enhanced developer productivit
 - [Micrometer](https://ge.micrometer.io)
 - [Micronaut](https://ge.micronaut.io)
 - [Nokee](https://ge.nokee.dev)
-- [OpenAPI Generator](https://community.develocity.cloud/scans?search.rootProjectNames=OpenAPITools)
+- [OpenAPI Generator](https://community.develocity.cloud/scans?search.rootProjectNames=openapi-generator-project)
 - [OpenRewrite](https://ge.openrewrite.org)
 - [OpenTelemetry](https://develocity.opentelemetry.io)
 - [Quarkus](https://ge.quarkus.io)
 - [Spock](https://ge.spockframework.org)
 - [Spring](https://ge.spring.io)
-- [Testcontainers](https://community.develocity.cloud/scans?search.rootProjectNames=testcontainers)
+- [Testcontainers](https://community.develocity.cloud/scans?search.rootProjectNames=testcontainers-java)
 - [XWiki](https://ge.xwiki.org)
 
 ## Learn more

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ The following OSS projects currently benefit from enhanced developer productivit
 - [Micrometer](https://ge.micrometer.io)
 - [Micronaut](https://ge.micronaut.io)
 - [Nokee](https://ge.nokee.dev)
-- [OpenAPI Generator](https://ge.openapi-generator.tech)
+- [OpenAPI Generator](https://community.develocity.cloud/scans?search.rootProjectNames=OpenAPITools)
 - [OpenRewrite](https://ge.openrewrite.org)
 - [OpenTelemetry](https://develocity.opentelemetry.io)
 - [Quarkus](https://ge.quarkus.io)
 - [Spock](https://ge.spockframework.org)
 - [Spring](https://ge.spring.io)
-- [Testcontainers](https://ge.testcontainers.org)
+- [Testcontainers](https://community.develocity.cloud/scans?search.rootProjectNames=testcontainers)
 - [XWiki](https://ge.xwiki.org)
 
 ## Learn more


### PR DESCRIPTION
## Summary

- Updates the Testcontainers link from `https://ge.testcontainers.org` to the filtered project view on the OSS Community Develocity Instance (`https://community.develocity.cloud/scans?search.rootProjectNames=testcontainers`)
- Updates the OpenAPI Generator link from `https://ge.openapi-generator.tech` to the filtered project view on the OSS Community Develocity Instance (`https://community.develocity.cloud/scans?search.rootProjectNames=OpenAPITools`)

Both projects have completed their migration to the community instance:
- testcontainers/testcontainers-java#11845
- OpenAPITools/openapi-generator#24050

## Test plan

- [ ] Verify the Testcontainers link resolves to the correct project scans on `community.develocity.cloud`
- [ ] Verify the OpenAPI Generator link resolves to the correct project scans on `community.develocity.cloud`

🤖 Generated with [Claude Code](https://claude.com/claude-code)