### PR TITLE
Migrate Spock link to community Develocity instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The following OSS projects currently benefit from enhanced developer productivit
 - [OpenRewrite](https://ge.openrewrite.org)
 - [OpenTelemetry](https://develocity.opentelemetry.io)
 - [Quarkus](https://ge.quarkus.io)
-- [Spock](https://ge.spockframework.org)
+- [Spock](https://community.develocity.cloud/scans?search.rootProjectNames=*spock*)
 - [Spring](https://ge.spring.io)
 - [Testcontainers](https://community.develocity.cloud/scans?search.rootProjectNames=testcontainers-java)
 - [XWiki](https://ge.xwiki.org)


### PR DESCRIPTION
Spock has migrated to the shared Community Develocity Instance, so its listing should point there instead of the old dedicated instance. Uses a wildcard filter (`rootProjectNames=*spock*`); Spock's Gradle `rootProject.name` is `spock`, so the filter returns its builds on the community instance.

- https://github.com/spockframework/spock/pull/2381