### PR TITLE
chore: remove Grails from resources list

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ The following OSS projects currently benefit from enhanced developer productivit
 - [Commonhaus Foundation](https://develocity.commonhaus.dev)
 - [Detekt](https://ge.detekt.dev)
 - [Gradle](https://ge.gradle.org)
-- [Grails](https://ge.grails.org)
 - [JUnit](https://ge.junit.org)
 - [Kotlin](https://ge.jetbrains.com)
 - [Micrometer](https://ge.micrometer.io)


### PR DESCRIPTION
Grails scans have been migrated to develocity.apache.org