### PR TITLE
Migrate Apollo Kotlin link to community Develocity instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The following OSS projects currently benefit from enhanced developer productivit
 - [AndroidX](https://androidx.develocity.cloud)
 - [The Apache Software Foundation](https://develocity.apache.org)
 - [Apereo](https://develocity.apereo.org)
-- [Apollo Kotlin](https://ge.apollographql.com)
+- [Apollo Kotlin](https://community.develocity.cloud/scans?search.rootProjectNames=*apollo*)
 - [Armeria](https://ge.armeria.dev)
 - [Caffeine](https://caffeine.gradle-enterprise.cloud)
 - [Commonhaus Foundation](https://develocity.commonhaus.dev)


### PR DESCRIPTION
Updates the Apollo Kotlin entry to point at the OSS Community Develocity Instance following its migration (`ge.apollographql.com` no longer the published instance).

Part of gradle/dv#68390. Mirrors #232 (OpenRewrite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)