### PR TITLE
Migrate XWiki link to community Develocity instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The following OSS projects currently benefit from enhanced developer productivit
 - [Spock](https://community.develocity.cloud/scans?search.rootProjectNames=*spock*)
 - [Spring](https://ge.spring.io)
 - [Testcontainers](https://community.develocity.cloud/scans?search.rootProjectNames=testcontainers-java)
-- [XWiki](https://ge.xwiki.org)
+- [XWiki](https://community.develocity.cloud/scans?search.rootProjectNames=*xwiki*)
 
 ## Learn more
 


### PR DESCRIPTION
Relates to gradle/dv#68400. Points the XWiki README entry at the shared community instance.